### PR TITLE
Fix build with vala 0.44

### DIFF
--- a/src/list-stack.vala
+++ b/src/list-stack.vala
@@ -73,7 +73,7 @@ public class ListStack : Gtk.Fixed
 
         return_if_fail (children != null);
 
-        unowned List<Gtk.Widget> prev = children.last ().prev;
+        unowned List<weak Gtk.Widget> prev = children.last ().prev;
         if (prev != null)
             (prev.data as GreeterList).greeter_box.pop ();
     }


### PR DESCRIPTION
vala 0.44.0 will be released in a few days as part of GNOME 3.32.

You can try the release candidate in Debian experimental.