### PR TITLE
 Remove marco WM due to logon screen bypass

### DIFF
--- a/src/arctica-greeter.vala
+++ b/src/arctica-greeter.vala
@@ -813,7 +813,6 @@ public class ArcticaGreeter
         string systemd_stderr;
         int systemd_exitcode = 0;
 
-        Pid marco_pid = 0;
         Pid nmapplet_pid = 0;
 
         var indicator_list = AGSettings.get_strv(AGSettings.KEY_INDICATORS);
@@ -837,24 +836,6 @@ public class ArcticaGreeter
         {
 
             activate_upower();
-
-            try
-            {
-                string[] argv;
-
-                Shell.parse_argv ("marco", out argv);
-                Process.spawn_async (null,
-                                     argv,
-                                     null,
-                                     SpawnFlags.SEARCH_PATH,
-                                     null,
-                                     out marco_pid);
-                debug ("Launched marco WM. PID: %d", marco_pid);
-            }
-            catch (Error e)
-            {
-                warning ("Error starting the Marco Window Manager: %s", e.message);
-            }
 
             greeter.greeter_ready.connect (() => {
                 debug ("Showing greeter");
@@ -1004,22 +985,6 @@ public class ArcticaGreeter
                 else
                     debug ("AT-SPI terminated with signal %d", Process.term_sig (status));
                 atspi_pid = 0;
-            }
-
-            if (marco_pid != 0)
-            {
-#if VALA_0_40
-                Posix.kill (marco_pid, Posix.Signal.TERM);
-#else
-                Posix.kill (marco_pid, Posix.SIGTERM);
-#endif
-                int status;
-                Posix.waitpid (marco_pid, out status, 0);
-                if (Process.if_exited (status))
-                    debug ("Marco Window Manager exited with return value %d", Process.exit_status (status));
-                else
-                    debug ("Marco Window Manager terminated with signal %d", Process.term_sig (status));
-                marco_pid = 0;
             }
         }
 


### PR DESCRIPTION
This commit removes invocation of MATE's window manager marco, that was introduced with 9b3526d12d9d6c828fbd4a29dec2295ae2f735a5

Having marco launched allows any user to use its keybindings to open applications which could bypass arctica-greeter and access the operating system as the "lightdm" user.