### PR TITLE
src/arctica-greeter.vala: Launch marco with '--no-keybindings' cmdlin…

### DIFF
--- a/src/arctica-greeter.vala
+++ b/src/arctica-greeter.vala
@@ -842,7 +842,7 @@ public class ArcticaGreeter
             {
                 string[] argv;
 
-                Shell.parse_argv ("marco", out argv);
+                Shell.parse_argv ("marco --no-keybindings", out argv);
                 Process.spawn_async (null,
                                      argv,
                                      null,


### PR DESCRIPTION
…e option.

 This requires a very recent version of marco, see [1].

 Fixes ArcticaProject/arctica-greeter#28.

 [1] https://github.com/mate-desktop/marco/pull/723