### PR TITLE
High Contrast mode changes and Big Font mode stub

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -91,6 +91,16 @@ if test x$gtk_check_pass = xyes ; then
   AC_SUBST([AM_VALAFLAGS])
 fi
 
+dnl ###########################################################################
+dnl Check for GTK version - 4.0
+dnl ###########################################################################
+
+PKG_CHECK_MODULES(GTK_4_0, gtk4 >= 4.0.0 , gtk4_check_pass=yes, gtk4_check_pass=no)
+if test x$gtk4_check_pass = xyes ; then
+  AM_VALAFLAGS="$AM_VALAFLAGS -D HAVE_GTK_4_0"
+  AC_SUBST([AM_VALAFLAGS])
+fi
+
 dnl ##########################################################################
 dnl Remote Logon Dependencies
 dnl ##########################################################################

--- a/data/org.ArcticaProject.arctica-greeter.gschema.xml
+++ b/data/org.ArcticaProject.arctica-greeter.gschema.xml
@@ -37,6 +37,10 @@
       <default>'Blue-Submarine'</default>
       <summary>GTK+ theme to use</summary>
     </key>
+    <key name="high-contrast-theme-name" type="s">
+      <default>'HighContrastInverse'</default>
+      <summary>GTK+ theme to use in high contrast mode</summary>
+    </key>
     <key name="icon-theme-name" type="s">
       <default>'Adwaita'</default>
       <summary>Icon theme to use</summary>
@@ -82,6 +86,10 @@
       <default>false</default>
       <summary>Whether to use a high contrast theme</summary>
     </key>
+    <key name="big-font" type="b">
+      <default>false</default>
+      <summary>Whether to use big fonts throughout the application</summary>
+    </key>
     <key name="screen-reader" type="b">
       <default>false</default>
       <summary>Whether to enable the screen reader</summary>
@@ -114,6 +122,10 @@
       </choices>
       <default>'auto'</default>
       <summary>Whether to enable HiDPI support</summary>
+    </key>
+    <key name="menubar-alpha" type="d">
+      <default>0.5</default>
+      <summary>Alpha value for menubar, multiplied with the theme-provided transparency value. Not used in high contrast mode.</summary>
     </key>
     <key name="remote-service-configure-uri" type="s">
       <default>''</default>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -37,7 +37,8 @@ arctica_greeter_SOURCES = \
 	toggle-box.vala \
 	arctica-greeter.vala \
 	user-list.vala \
-	user-prompt-box.vala
+	user-prompt-box.vala \
+	util.vala
 
 logo_generator_SOURCES = logo-generator.vala
 

--- a/src/arctica-greeter.vala
+++ b/src/arctica-greeter.vala
@@ -807,6 +807,16 @@ public class ArcticaGreeter
         if (value != "")
             settings.set ("gtk-xft-rgba", value, null);
 
+        /*
+         * Keep a reference to an AGSettings instance for the whole program
+         * run, so that the SingleInstance property is working the way we'd
+         * like it to work.
+         *
+         * We want to do this before creating the actual greeter, since the
+         * latter is using AGSettings quite extensively.
+         */
+        var agsettings = new AGSettings ();
+
         debug ("Creating Arctica Greeter");
         var greeter = new ArcticaGreeter (do_test_mode);
 

--- a/src/background.vala
+++ b/src/background.vala
@@ -778,7 +778,8 @@ public class Background : Gtk.Fixed
     {
         notify_property ("average-color");
 
-        if (!ArcticaGreeter.singleton.test_mode)
+        var greeter = new ArcticaGreeter ();
+        if (!greeter.test_mode)
         {
             var rgba = current.average_color.to_string ();
             var root = get_screen ().get_root_window ();

--- a/src/dash-box.vala
+++ b/src/dash-box.vala
@@ -54,7 +54,8 @@ public class DashBox : Gtk.Box
     /* Does not actually add w to this widget, as doing so would potentially mess with w's placement. */
     public void set_base (Gtk.Widget? w)
     {
-        if (!ArcticaGreeter.singleton.test_mode) {
+        var greeter = new ArcticaGreeter ();
+        if (!greeter.test_mode) {
             return_if_fail (pushed == null);
             return_if_fail (mode == Mode.NORMAL);
         }

--- a/src/dash-box.vala
+++ b/src/dash-box.vala
@@ -221,10 +221,25 @@ public class DashBox : Gtk.Box
 
         CairoUtils.rounded_rectangle (c, 0, box_y, box_w, box_h, box_r);
 
-        c.set_source_rgba (0.1, 0.1, 0.1, 0.4);
+        var agsettings = new AGSettings ();
+        if (agsettings.high_contrast)
+        {
+            c.set_source_rgba (1.0, 1.0, 1.0, 1.0);
+        }
+        else
+        {
+            c.set_source_rgba (0.1, 0.1, 0.1, 0.4);
+        }
         c.fill_preserve ();
 
-        c.set_source_rgba (0.4, 0.4, 0.4, 0.4);
+        if (agsettings.high_contrast)
+        {
+            c.set_source_rgba (0.0, 0.0, 0.0, 1.0);
+        }
+        else
+        {
+            c.set_source_rgba (0.4, 0.4, 0.4, 0.4);
+        }
         c.set_line_width (1);
         c.stroke ();
 

--- a/src/dash-entry.vala
+++ b/src/dash-entry.vala
@@ -301,10 +301,11 @@ public class DashEntry : Gtk.Entry, Fadable
         // This is a workaround for bug https://launchpad.net/bugs/944159
         // The problem is that orca seems to not notice that it's in a password
         // field on startup.  We just need to kick orca in the pants.
-        if (ArcticaGreeter.singleton.orca_needs_kick)
+        var greeter = new ArcticaGreeter ();
+        if (greeter.orca_needs_kick)
         {
             Signal.emit_by_name (get_accessible (), "focus-event", true);
-            ArcticaGreeter.singleton.orca_needs_kick = false;
+            greeter.orca_needs_kick = false;
         }
 
         return base.key_press_event (event);

--- a/src/greeter-list.vala
+++ b/src/greeter-list.vala
@@ -229,7 +229,8 @@ public abstract class GreeterList : FadableBox
 
     public void cancel_authentication ()
     {
-        ArcticaGreeter.singleton.cancel_authentication ();
+        var greeter = new ArcticaGreeter ();
+        greeter.cancel_authentication ();
         entry_selected (selected_entry.id);
     }
 
@@ -483,7 +484,8 @@ public abstract class GreeterList : FadableBox
         entry.destroy ();
 
         /* Show a manual login if no users and no remote login entry */
-        if (!have_entries () && !ArcticaGreeter.singleton.show_remote_login_hint ())
+        var greeter = new ArcticaGreeter ();
+        if (!have_entries () && !greeter.show_remote_login_hint ())
             add_manual_entry ();
 
         queue_draw ();
@@ -793,9 +795,10 @@ public abstract class GreeterList : FadableBox
 
     protected void connect_to_lightdm ()
     {
-        ArcticaGreeter.singleton.show_message.connect (show_message_cb);
-        ArcticaGreeter.singleton.show_prompt.connect (show_prompt_cb);
-        ArcticaGreeter.singleton.authentication_complete.connect (authentication_complete_cb);
+        var greeter = new ArcticaGreeter ();
+        greeter.show_message.connect (show_message_cb);
+        greeter.show_prompt.connect (show_prompt_cb);
+        greeter.authentication_complete.connect (authentication_complete_cb);
     }
 
     protected void show_message_cb (string text, LightDM.MessageType type)
@@ -809,10 +812,11 @@ public abstract class GreeterList : FadableBox
         /* Notify the greeter on what user has been logged */
         if (get_selected_id () == "*other" && manual_name == null)
         {
-            if (ArcticaGreeter.singleton.test_mode)
+            var greeter = new ArcticaGreeter ();
+            if (greeter.test_mode)
                 manual_name = test_username;
             else
-                manual_name = ArcticaGreeter.singleton.authentication_user();
+                manual_name = greeter.authentication_user();
         }
 
         prompted = true;
@@ -841,10 +845,11 @@ public abstract class GreeterList : FadableBox
             return;
 
         bool is_authenticated;
-        if (ArcticaGreeter.singleton.test_mode)
+        var greeter = new ArcticaGreeter ();
+        if (greeter.test_mode)
             is_authenticated = test_is_authenticated;
         else
-            is_authenticated = ArcticaGreeter.singleton.is_authenticated();
+            is_authenticated = greeter.is_authenticated();
 
         if (is_authenticated)
         {
@@ -852,7 +857,7 @@ public abstract class GreeterList : FadableBox
             if (prompted && !unacknowledged_messages)
             {
                 login_complete ();
-                if (ArcticaGreeter.singleton.test_mode)
+                if (greeter.test_mode)
                     start_session ();
                 else
                 {
@@ -905,16 +910,17 @@ public abstract class GreeterList : FadableBox
 
         greeter_authenticating_user = get_selected_id ();
 
-        if (ArcticaGreeter.singleton.test_mode)
+        var greeter = new ArcticaGreeter ();
+        if (greeter.test_mode)
             test_start_authentication ();
         else
         {
             if (get_selected_id () == "*other")
-                ArcticaGreeter.singleton.authenticate ();
+                greeter.authenticate ();
             else if (get_selected_id () == "*guest")
-                ArcticaGreeter.singleton.authenticate_as_guest ();
+                greeter.authenticate_as_guest ();
             else
-                ArcticaGreeter.singleton.authenticate (get_selected_id ());
+                greeter.authenticate (get_selected_id ());
         }
     }
 
@@ -929,7 +935,8 @@ public abstract class GreeterList : FadableBox
 
     private void start_session ()
     {
-        if (!ArcticaGreeter.singleton.start_session (get_lightdm_session (), background))
+        var greeter = new ArcticaGreeter ();
+        if (!greeter.start_session (get_lightdm_session (), background))
         {
             show_message (_("Failed to start session"), true);
             start_authentication ();

--- a/src/main-window.vala
+++ b/src/main-window.vala
@@ -40,7 +40,7 @@ public class MainWindow : Gtk.Window
     public ListStack stack;
 
     // Menubar is smaller, but with shadow, we reserve more space
-    public const int MENUBAR_HEIGHT = 32;
+    public const int MENUBAR_HEIGHT = 40;
 
     construct
     {
@@ -75,6 +75,8 @@ public class MainWindow : Gtk.Window
             shadow_style = "background-image: url('%s');
                             background-repeat: repeat;".printf(shadow_path);
         }
+        /* Disable the shadow image, we will use CSS instead. */
+        /*
         try
         {
             var style = new Gtk.CssProvider ();
@@ -89,6 +91,7 @@ public class MainWindow : Gtk.Window
         {
             debug ("Internal error loading menubox style: %s", e.message);
         }
+        */
         menubox.set_size_request (-1, MENUBAR_HEIGHT);
         menubox.show ();
         menualign.show ();

--- a/src/main-window.vala
+++ b/src/main-window.vala
@@ -159,7 +159,8 @@ public class MainWindow : Gtk.Window
         only_on_monitor = AGSettings.get_string(AGSettings.KEY_ONLY_ON_MONITOR);
         monitor_setting_ok = only_on_monitor == "auto";
 
-        if (ArcticaGreeter.singleton.test_mode)
+        var greeter = new ArcticaGreeter ();
+        if (greeter.test_mode)
         {
             /* Simulate an 800x600 monitor to the left of a 640x480 monitor */
             monitors = new List<Monitor> ();
@@ -375,6 +376,7 @@ public class MainWindow : Gtk.Window
             }
         }
 
+        var greeter = new ArcticaGreeter ();
         switch (event.keyval)
         {
         case Gdk.Key.Escape:
@@ -434,14 +436,14 @@ public class MainWindow : Gtk.Window
             }
             return true;
         case Gdk.Key.z:
-            if (ArcticaGreeter.singleton.test_mode && (event.state & Gdk.ModifierType.MOD1_MASK) != 0)
+            if (greeter.test_mode && (event.state & Gdk.ModifierType.MOD1_MASK) != 0)
             {
                 show_shutdown_dialog (ShutdownDialogType.SHUTDOWN);
                 return true;
             }
             break;
         case Gdk.Key.Z:
-            if (ArcticaGreeter.singleton.test_mode && (event.state & Gdk.ModifierType.MOD1_MASK) != 0)
+            if (greeter.test_mode && (event.state & Gdk.ModifierType.MOD1_MASK) != 0)
             {
                 show_shutdown_dialog (ShutdownDialogType.RESTART);
                 return true;

--- a/src/menubar.vala
+++ b/src/menubar.vala
@@ -108,7 +108,8 @@ public class MenuBar : Gtk.MenuBar
      */
     public void set_keyboard_state ()
     {
-        if (!ArcticaGreeter.singleton.test_mode)
+        var greeter = new ArcticaGreeter ();
+        if (!greeter.test_mode)
             onscreen_keyboard_item.set_active (AGSettings.get_boolean (AGSettings.KEY_ONSCREEN_KEYBOARD));
     }
 
@@ -155,7 +156,8 @@ public class MenuBar : Gtk.MenuBar
 
         setup_indicators ();
 
-        ArcticaGreeter.singleton.starting_session.connect (cleanup);
+        var greeter = new ArcticaGreeter ();
+        greeter.starting_session.connect (cleanup);
     }
 
     private void close_pid (ref Pid pid)
@@ -293,7 +295,8 @@ public class MenuBar : Gtk.MenuBar
 
     private void load_indicator (string indicator_name)
     {
-        if (!ArcticaGreeter.singleton.test_mode)
+        var greeter = new ArcticaGreeter ();
+        if (!greeter.test_mode)
         {
             if (indicator_name == "ug-accessibility")
             {
@@ -484,7 +487,8 @@ public class MenuBar : Gtk.MenuBar
                 // this is not racy with orca startup, it is racy with whether
                 // orca will read the first character or not out loud.  Hence
                 // why we do both.  Ideally this would be fixed in orca itself.
-                ArcticaGreeter.singleton.orca_needs_kick = true;
+                var greeter = new ArcticaGreeter ();
+                greeter.orca_needs_kick = true;
                 Timeout.add_seconds (1, () => {
                     Signal.emit_by_name ((get_toplevel () as Gtk.Window).get_focus ().get_accessible (), "focus-event", true);
                     return false;

--- a/src/menubar.vala
+++ b/src/menubar.vala
@@ -365,11 +365,15 @@ public class MenuBar : Gtk.MenuBar
         var agsettings = new AGSettings ();
         debug ("Initializing high contrast menu item to state %s", agsettings.high_contrast.to_string ());
         high_contrast_item.set_active (agsettings.high_contrast);
+
+/* Hide the Big Font feature until it's available.
         big_font_item = new Gtk.CheckMenuItem.with_label (_("Big Font"));
         big_font_item.toggled.connect (big_font_toggled_cb);
         big_font_item.add_accelerator ("activate", accel_group, Gdk.Key.b, Gdk.ModifierType.CONTROL_MASK, Gtk.AccelFlags.VISIBLE);
         big_font_item.show ();
         submenu.append (big_font_item);
+*/
+
         big_font_item.set_active (agsettings.big_font);
         var item = new Gtk.CheckMenuItem.with_label (_("Screen Reader"));
         item.toggled.connect (screen_reader_toggled_cb);

--- a/src/session-list.vala
+++ b/src/session-list.vala
@@ -44,7 +44,8 @@ public class SessionPrompt : PromptBox
 
         box = new ToggleBox (default_session, session);
 
-        if (ArcticaGreeter.singleton.test_mode)
+        var greeter = new ArcticaGreeter ();
+        if (greeter.test_mode)
         {
             box.add_item ("gnome", "GNOME", SessionList.get_badge ("gnome"));
             box.add_item ("kde", "KDE", SessionList.get_badge ("kde"));

--- a/src/settings.vala
+++ b/src/settings.vala
@@ -31,6 +31,7 @@ public class AGSettings : Object
     public const string KEY_SHOW_HOSTNAME = "show-hostname";
     public const string KEY_LOGO = "logo";
     public const string KEY_THEME_NAME = "theme-name";
+    public const string KEY_HIGH_CONTRAST_THEME_NAME = "high-contrast-theme-name";
     public const string KEY_ICON_THEME_NAME = "icon-theme-name";
     public const string KEY_FONT_NAME = "font-name";
     public const string KEY_XFT_ANTIALIAS = "xft-antialias";
@@ -39,6 +40,7 @@ public class AGSettings : Object
     public const string KEY_XFT_RGBA = "xft-rgba";
     public const string KEY_ONSCREEN_KEYBOARD = "onscreen-keyboard";
     public const string KEY_HIGH_CONTRAST = "high-contrast";
+    public const string KEY_BIG_FONT = "big-font";
     public const string KEY_SCREEN_READER = "screen-reader";
     public const string KEY_PLAY_READY_SOUND = "play-ready-sound";
     public const string KEY_INDICATORS = "indicators";
@@ -51,6 +53,8 @@ public class AGSettings : Object
     public const string KEY_TOGGLEBOX_FONT_FGCOLOR = "togglebox-font-fgcolor";
     public const string KEY_TOGGLEBOX_BUTTON_BGCOLOR = "togglebox-button-bgcolor";
     public const string KEY_ENABLE_HIDPI = "enable-hidpi";
+    public const string KEY_MENUBAR_ALPHA = "menubar-alpha";
+
 
     public static bool get_boolean (string key)
     {
@@ -112,7 +116,63 @@ public class AGSettings : Object
     }
 
     construct {
+        Gtk.Settings.get_default ().get ("gtk-theme-name", out this.default_theme_name_);
+        /*
+        debug ("Fetched default theme name in construct: %s", this.default_theme_name_);
+        */
+    }
+
+    public bool high_contrast {
+        get {
+            return this.high_contrast_;
+        }
+
+        set {
+            debug ("Called high contrast setter with value %s", value.to_string ());
+            this.high_contrast_ = value;
+
+            /* Also sync back to dconf, so that this state is persistent. */
+            set_boolean (AGSettings.KEY_HIGH_CONTRAST, value);
+
+            var greeter = new ArcticaGreeter ();
+            greeter.switch_contrast (value);
+
+            var settings = Gtk.Settings.get_default ();
+            if (value)
+            {
+                /*
+                debug ("Switching GTK Theme to high contrast theme \"%s\"", AGSettings.get_string (AGSettings.KEY_HIGH_CONTRAST_THEME_NAME));
+                */
+                settings.set ("gtk-theme-name", AGSettings.get_string (AGSettings.KEY_HIGH_CONTRAST_THEME_NAME));
+            }
+            else
+            {
+                /*
+                debug ("Switching GTK Theme to default theme \"%s\"", this.default_theme_name_);
+                */
+                settings.set ("gtk-theme-name", this.default_theme_name_);
+            }
+        }
+    }
+
+    public bool big_font {
+        get {
+            return this.big_font_;
+        }
+
+        set {
+            this.big_font_ = value;
+
+            /* Also sync back to dconf, so that this state is persistent. */
+            set_boolean (AGSettings.KEY_BIG_FONT, value);
+
+            var greeter = new ArcticaGreeter ();
+            greeter.switch_font (value);
+        }
     }
 
     private const string SCHEMA = "org.ArcticaProject.arctica-greeter";
+    private bool high_contrast_ = AGSettings.get_boolean (AGSettings.KEY_HIGH_CONTRAST);
+    private bool big_font_ = AGSettings.get_boolean (AGSettings.KEY_BIG_FONT);
+    private string default_theme_name_;
 }

--- a/src/settings.vala
+++ b/src/settings.vala
@@ -2,6 +2,7 @@
  *
  * Copyright (C) 2011,2012 Canonical Ltd
  * Copyright (C) 2015,2017 Mike Gabriel <mike.gabriel@das-netzwerkteam.de>
+ * Copyright (C) 2022 Mihai Moldovan <ionic@ionic.de>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -20,7 +21,8 @@
  *          Mike Gabriel <mike.gabriel@das-netzwerkteam.de>
  */
 
-public class AGSettings
+[SingleInstance]
+public class AGSettings : Object
 {
     public const string KEY_BACKGROUND = "background";
     public const string KEY_BACKGROUND_COLOR = "background-color";
@@ -103,6 +105,13 @@ public class AGSettings
     {
         var gsettings = new Settings (SCHEMA);
         return gsettings.set_strv (key, value);
+    }
+
+    public AGSettings ()
+    {
+    }
+
+    construct {
     }
 
     private const string SCHEMA = "org.ArcticaProject.arctica-greeter";

--- a/src/toggle-box.vala
+++ b/src/toggle-box.vala
@@ -70,8 +70,21 @@ public class ToggleBox : Gtk.Box
                                   "   background-image: none;"+
                                   "}\n"+
                                   "button:hover,\n"+
-                                  "button:hover:active {\n"+
+                                  "button:active,\n" +
+                                  "button:hover:active,\n" +
+                                  "button.selected {\n"+
                                   "   background-color: %s;\n".printf(AGSettings.get_string (AGSettings.KEY_TOGGLEBOX_BUTTON_BGCOLOR))+
+                                  "}\n" +
+                                  "button.high_contrast {\n" +
+                                  "   background-color: %s;\n".printf ("rgba(70, 70, 70, 1.0)") +
+                                  "   background-image: none;\n" +
+                                  "   border-color: %s\n;".printf ("rgba(0, 0, 0, 1.0)") +
+                                  "}\n" +
+                                  "button.high_contrast:hover,\n" +
+                                  "button.high_contrast:active,\n" +
+                                  "button.high_contrast:hover:active,\n" +
+                                  "button.high_contrast.selected {\n" +
+                                  "   background-color: %s;\n".printf ("rgba(0, 0, 0, 1.0)") +
                                   "}\n", -1);
             button.get_style_context ().add_provider (style, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
         }
@@ -113,9 +126,8 @@ public class ToggleBox : Gtk.Box
         selected_button = button;
         selected_key = selected_button.get_data<string> ("toggle-list-key");
 
-        var bg_color = Gdk.RGBA ();
-        bg_color.parse (AGSettings.get_string (AGSettings.KEY_TOGGLEBOX_BUTTON_BGCOLOR));
-        selected_button.override_background_color(Gtk.StateFlags.NORMAL, bg_color);
+        /* Handle color via CSS. */
+        selected_button.get_style_context ().add_class ("selected");
     }
 
     private Gtk.Button make_button (string key, string name_in, Gdk.Pixbuf? icon)
@@ -140,7 +152,24 @@ public class ToggleBox : Gtk.Box
         }
 
         var label = new Gtk.Label (null);
-        label.set_markup ("<span font=\"%s %d\" fgcolor=\"%s\">%s</span>".printf (font_family, font_size+2, AGSettings.get_string (AGSettings.KEY_TOGGLEBOX_FONT_FGCOLOR), name));
+        /* Font and other properties are being handled via CSS. */
+        label.set_text (name);
+        try {
+            var style = new Gtk.CssProvider ();
+            style.load_from_data ("label {\n" +
+                                  "   font-family: \"%s\", sans-serif;\n".printf (font_family) +
+                                  "   font-size: %d;\n".printf (font_size + 2) +
+                                  "   color: %s;\n".printf (AGSettings.get_string (AGSettings.KEY_TOGGLEBOX_FONT_FGCOLOR)) +
+                                  "}\n" +
+                                  "label.high_contrast {\n" +
+                                  "   color: %s;\n".printf ("rgba(255, 255, 255, 1.0)") +
+                                  "}\n", -1);
+            label.get_style_context ().add_provider (style, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+        }
+        catch (Error e)
+        {
+            debug ("Internal error loading session chooser label style: %s", e.message);
+        }
         label.halign = Gtk.Align.START;
         hbox.pack_start (label, true, true, 0);
 

--- a/src/toggle-box.vala
+++ b/src/toggle-box.vala
@@ -65,12 +65,12 @@ public class ToggleBox : Gtk.Box
             /* Tighten padding on buttons to not be so large, default color scheme for buttons */
             var style = new Gtk.CssProvider ();
             style.load_from_data ("* {padding: 8px;}\n"+
-                                  "GtkButton {\n"+
+                                  "GtkButton, button {\n"+
                                   "   background-color: %s;\n".printf("rgba(0,0,0,0)")+
                                   "   background-image: none;"+
                                   "}\n"+
-                                  ".button:hover,\n"+
-                                  ".button:hover:active {\n"+
+                                  "button:hover,\n"+
+                                  "button:hover:active {\n"+
                                   "   background-color: %s;\n".printf(AGSettings.get_string (AGSettings.KEY_TOGGLEBOX_BUTTON_BGCOLOR))+
                                   "}\n", -1);
             button.get_style_context ().add_provider (style, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);

--- a/src/user-list.vala
+++ b/src/user-list.vala
@@ -73,7 +73,8 @@ public class UserList : GreeterList
         {
             show_hidden_users_ = value;
 
-            if (ArcticaGreeter.singleton.test_mode)
+            var greeter = new ArcticaGreeter ();
+            if (greeter.test_mode)
             {
                 if (value)
                     add_user ("hidden", "Hidden User", null, false, false, null);
@@ -166,8 +167,9 @@ public class UserList : GreeterList
 
         connect_to_lightdm ();
 
-        if (!ArcticaGreeter.singleton.test_mode &&
-            ArcticaGreeter.singleton.show_remote_login_hint ())
+        var greeter = new ArcticaGreeter ();
+        if (!greeter.test_mode &&
+            greeter.show_remote_login_hint ())
             remote_logon_service_watch = Bus.watch_name (BusType.SESSION,
                                             "org.ArcticaProject.RemoteLogon",
                                             BusNameWatcherFlags.AUTO_START,
@@ -390,7 +392,8 @@ public class UserList : GreeterList
         remote_logon_service = null;
 
         /* provide a fallback manual login option */
-        if (ArcticaGreeter.singleton.hide_users_hint ()) {
+        var greeter = new ArcticaGreeter ();
+        if (greeter.hide_users_hint ()) {
             add_manual_entry();
             set_active_entry ("*other");
         }
@@ -443,10 +446,11 @@ public class UserList : GreeterList
         else
         {
             var login_success = false;
+            var greeter = new ArcticaGreeter ();
             try
             {
                 var url = url_from_remote_loding_server_list_name (selected_entry.id);
-                if (ArcticaGreeter.singleton.test_mode)
+                if (greeter.test_mode)
                 {
                     if (password_field.text == "password")
                     {
@@ -528,7 +532,8 @@ public class UserList : GreeterList
         sensitive = false;
         will_clear = true;
         greeter_authenticating_user = selected_entry.id;
-        if (ArcticaGreeter.singleton.test_mode)
+        var greeter = new ArcticaGreeter ();
+        if (greeter.test_mode)
         {
             Gtk.Entry field = current_remote_fields.get ("password") as Gtk.Entry;
             test_is_authenticated = field.text == "password";
@@ -539,7 +544,7 @@ public class UserList : GreeterList
         }
         else
         {
-            ArcticaGreeter.singleton.authenticate_remote (get_lightdm_session (), null);
+            greeter.authenticate_remote (get_lightdm_session (), null);
             remote_logon_service.set_last_used_server.begin (currently_browsing_server_url, url_from_remote_loding_server_list_name (selected_entry.id));
         }
     }
@@ -576,7 +581,8 @@ public class UserList : GreeterList
                 if (is_supported_remote_session (config_session))
                 {
                     greeter_authenticating_user = selected_entry.id;
-                    ArcticaGreeter.singleton.authenticate_remote (config_session, null);
+                    var greeter = new ArcticaGreeter ();
+                    greeter.authenticate_remote (config_session, null);
                 }
             }
             dialog.destroy ();
@@ -635,7 +641,8 @@ public class UserList : GreeterList
 
     private void entry_selected_cb (string? username)
     {
-        ArcticaGreeter.singleton.set_state ("last-user", username);
+        var greeter = new ArcticaGreeter ();
+        greeter.set_state ("last-user", username);
         if (selected_entry is UserPromptBox)
             session = (selected_entry as UserPromptBox).session;
         else
@@ -777,9 +784,10 @@ public class UserList : GreeterList
                     else if (field.type == "email")
                     {
                         string[] email_domains;
+                        var greeter = new ArcticaGreeter ();
                         try
                         {
-                            if (ArcticaGreeter.singleton.test_mode)
+                            if (greeter.test_mode)
                                 email_domains = { "canonical.com", "ubuntu.org", "candy.com", "urban.net" };
                             else
                                 yield remote_logon_service.get_cached_domains_for_server (url, out email_domains);
@@ -889,12 +897,13 @@ public class UserList : GreeterList
         will_clear = true;
         unacknowledged_messages = false;
 
+        var greeter = new ArcticaGreeter ();
         foreach (var response in responses)
         {
-            if (ArcticaGreeter.singleton.test_mode)
+            if (greeter.test_mode)
                 test_respond (response);
             else
-                ArcticaGreeter.singleton.respond (response);
+                greeter.respond (response);
         }
     }
 
@@ -904,10 +913,11 @@ public class UserList : GreeterList
 
         unacknowledged_messages = false;
         var is_authenticated = false;
-        if (ArcticaGreeter.singleton.test_mode)
+        var greeter = new ArcticaGreeter ();
+        if (greeter.test_mode)
             is_authenticated = test_is_authenticated;
         else
-            is_authenticated = ArcticaGreeter.singleton.is_authenticated();
+            is_authenticated = greeter.is_authenticated();
 
         /* Finish authentication (again) or restart it */
         if (is_authenticated)
@@ -923,18 +933,21 @@ public class UserList : GreeterList
     {
         var session_chooser = new SessionList (background, menubar, session, default_session);
         session_chooser.session_clicked.connect (session_clicked_cb);
-        ArcticaGreeter.singleton.push_list (session_chooser);
+        var greeter = new ArcticaGreeter ();
+        greeter.push_list (session_chooser);
     }
 
     private void session_clicked_cb (string session)
     {
         this.session = session;
-        ArcticaGreeter.singleton.pop_list ();
+        var greeter = new ArcticaGreeter ();
+        greeter.pop_list ();
     }
 
     private bool should_show_session_badge ()
     {
-        if (ArcticaGreeter.singleton.test_mode)
+        var greeter = new ArcticaGreeter ();
+        if (greeter.test_mode)
             return get_selected_id () != "no-badge";
         else
             return LightDM.get_sessions ().length () > 1;
@@ -962,7 +975,8 @@ public class UserList : GreeterList
 
     private bool is_supported_remote_session (string session_internal_name)
     {
-        if (ArcticaGreeter.singleton.test_mode)
+        var greeter = new ArcticaGreeter ();
+        if (greeter.test_mode)
             return session_internal_name == "rdp";
 
         var found = false;
@@ -1004,13 +1018,14 @@ public class UserList : GreeterList
 
     private void fill_list ()
     {
-        if (ArcticaGreeter.singleton.test_mode)
+        var greeter = new ArcticaGreeter ();
+        if (greeter.test_mode)
             test_fill_list ();
         else
         {
-            default_session = ArcticaGreeter.singleton.default_session_hint ();
-            always_show_manual = ArcticaGreeter.singleton.show_manual_login_hint ();
-            if (!ArcticaGreeter.singleton.hide_users_hint ())
+            default_session = greeter.default_session_hint ();
+            always_show_manual = greeter.show_manual_login_hint ();
+            if (!greeter.hide_users_hint ())
             {
                 var users = LightDM.UserList.get_instance ();
                 users.user_added.connect (user_added_cb);
@@ -1020,7 +1035,7 @@ public class UserList : GreeterList
                     user_added_cb (user);
             }
 
-            if (ArcticaGreeter.singleton.has_guest_account_hint ())
+            if (greeter.has_guest_account_hint ())
             {
                 debug ("Adding guest account entry");
                 offer_guest = true;
@@ -1030,9 +1045,9 @@ public class UserList : GreeterList
             if (!have_entries ())
                 add_manual_entry ();
 
-            var last_user = ArcticaGreeter.singleton.get_state ("last-user");
-            if (ArcticaGreeter.singleton.select_user_hint () != null)
-                set_active_entry (ArcticaGreeter.singleton.select_user_hint ());
+            var last_user = greeter.get_state ("last-user");
+            if (greeter.select_user_hint () != null)
+                set_active_entry (greeter.select_user_hint ());
             else if (last_user != null)
                 set_active_entry (last_user);
         }
@@ -1098,39 +1113,40 @@ public class UserList : GreeterList
     {
         if (selected_entry.id.has_prefix ("*remote_login"))
         {
+            var greeter = new ArcticaGreeter ();
             if ((text == pam_x2go.PROMPT_USER) || (text == pam_freerdp2.PROMPT_USER))
             {
                 Gtk.Entry field = current_remote_fields.get ("username") as Gtk.Entry;
                 var answer = field != null ? field.text : "";
                 debug ("remote_login prompt parsing: username -> %s", answer);
-                ArcticaGreeter.singleton.respond (answer);
+                greeter.respond (answer);
             }
             else if ((text == pam_x2go.PROMPT_PASSWORD) || (text == pam_freerdp2.PROMPT_PASSWORD))
             {
                 Gtk.Entry field = current_remote_fields.get ("password") as Gtk.Entry;
                 var answer = field != null ? field.text : "";
                 debug ("remote_login prompt parsing: password -> <hidden>");
-                ArcticaGreeter.singleton.respond (answer);
+                greeter.respond (answer);
             }
             else if ((text == pam_x2go.PROMPT_HOST) || (text == pam_freerdp2.PROMPT_HOST))
             {
                 var answer = url_from_remote_loding_server_list_name (selected_entry.id);
                 debug ("remote_login prompt parsing: host -> %s", answer);
-                ArcticaGreeter.singleton.respond (answer);
+                greeter.respond (answer);
             }
             else if (text == pam_freerdp2.PROMPT_DOMAIN)
             {
                 Gtk.Entry field = current_remote_fields.get ("domain") as Gtk.Entry;
                 var answer = field != null ? field.text : "";
                 debug ("remote_login prompt parsing: domain -> %s", answer);
-                ArcticaGreeter.singleton.respond (answer);
+                greeter.respond (answer);
             }
             else if (text == pam_x2go.PROMPT_COMMAND)
             {
                 Gtk.Entry field = current_remote_fields.get ("command") as Gtk.Entry;
                 var answer = field != null ? field.text : "";
                 debug ("remote_login prompt parsing: command -> %s", answer);
-                ArcticaGreeter.singleton.respond (answer);
+                greeter.respond (answer);
             }
         }
         else
@@ -1210,7 +1226,8 @@ public class UserList : GreeterList
         {
         }
 
-        if (!ArcticaGreeter.singleton.hide_users_hint())
+        var greeter = new ArcticaGreeter ();
+        if (!greeter.hide_users_hint())
             while (add_test_entry ());
 
         /* add a manual entry if the list of entries is empty initially */
@@ -1221,12 +1238,12 @@ public class UserList : GreeterList
             n_test_entries++;
         }
 
-        offer_guest = ArcticaGreeter.singleton.has_guest_account_hint();
-        always_show_manual = ArcticaGreeter.singleton.show_manual_login_hint();
+        offer_guest = greeter.has_guest_account_hint();
+        always_show_manual = greeter.show_manual_login_hint();
 
         key_press_event.connect (test_key_press_cb);
 
-        if (ArcticaGreeter.singleton.show_remote_login_hint())
+        if (greeter.show_remote_login_hint())
             Timeout.add (1000, () =>
             {
                 RemoteServer[] test_server_list = {};
@@ -1248,7 +1265,7 @@ public class UserList : GreeterList
                 return false;
             });
 
-        var last_user = ArcticaGreeter.singleton.get_state ("last-user");
+        var last_user = greeter.get_state ("last-user");
         if (last_user != null)
             set_active_entry (last_user);
 

--- a/src/user-list.vala
+++ b/src/user-list.vala
@@ -148,7 +148,8 @@ public class UserList : GreeterList
 
     construct
     {
-        menubar.notify["high-contrast"].connect (() => { change_background (); });
+        var agsettings = new AGSettings ();
+        agsettings.notify["high-contrast"].connect (() => { change_background (); });
         entry_displayed_start.connect (() => { change_background (); });
         entry_displayed_done.connect (() => { change_background (); });
 
@@ -593,7 +594,8 @@ public class UserList : GreeterList
     private bool change_background_timeout_cb ()
     {
         string? new_background_file = null;
-        if (menubar.high_contrast || !AGSettings.get_boolean (AGSettings.KEY_DRAW_USER_BACKGROUNDS))
+        var agsettings = new AGSettings ();
+        if (agsettings.high_contrast || !AGSettings.get_boolean (AGSettings.KEY_DRAW_USER_BACKGROUNDS))
             new_background_file = null;
         else if (selected_entry is UserPromptBox)
             new_background_file = (selected_entry as UserPromptBox).background;

--- a/src/util.vala
+++ b/src/util.vala
@@ -1,0 +1,28 @@
+/* -*- Mode: Vala; indent-tabs-mode: nil; tab-width: 4 -*-
+ *
+ * Copyright (C) 2011,2012 Canonical Ltd
+ * Copyright (C) 2015-2017 Mike Gabriel <mike.gabriel@das-netzwerkteam.de>
+ * Copyright (C) 2022 Mihai Moldovan <ionic@ionic.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors: Robert Ancell <robert.ancell@canonical.com>
+ *          Michael Terry <michael.terry@canonical.com>
+ *          Mike Gabriel <mike.gabriel@das-netzwerkteam.de>
+ *          Mihai Moldovan <ionic@ionic.de>
+ */
+
+#if !HAVE_GTK_4_0
+[CCode(cname = "GTK_IS_CONTAINER", cheader_filename="gtk/gtk.h", simple_generics = true, has_target = false)]
+static extern bool gtk_is_container<T> (T widget);
+#endif

--- a/tests/arctica-greeter.vala
+++ b/tests/arctica-greeter.vala
@@ -19,7 +19,8 @@
 
 public const int grid_size = 40;
 
-public class ArcticaGreeter
+[SingleInstance]
+public class ArcticaGreeter : Object
 {
     public static ArcticaGreeter singleton;
 
@@ -27,10 +28,15 @@ public class ArcticaGreeter
     public signal void show_prompt (string text, LightDM.PromptType type);
     public signal void authentication_complete ();
 
-    public bool test_mode = false;
+    public bool test_mode { get; construct; default = false; }
     public bool session_started = false;
     public string last_respond_response;
     public bool orca_needs_kick;
+
+    public ArcticaGreeter (bool test_mode_ = false)
+    {
+        Object (test_mode: test_mode_);
+    }
 
     public bool is_authenticated ()
     {

--- a/tests/menubar.vala
+++ b/tests/menubar.vala
@@ -19,7 +19,6 @@
 public class MenuBar : Gtk.MenuBar
 {
     public const int HEIGHT = 32;
-    public bool high_contrast { get; private set; default = false; }
 
     public MenuBar (Background bg, Gtk.AccelGroup ag)
     {

--- a/tests/test.vala
+++ b/tests/test.vala
@@ -137,6 +137,21 @@ public class Test
         }
     }
 
+    public static void greeter_test_mode ()
+    {
+        var greeter = new ArcticaGreeter ();
+
+        /*
+         * Test that fetching the greeter singleton worked, even though we use
+         * the default value for test mode (false).
+         */
+        GLib.assert (true == greeter.test_mode);
+
+        // And explicitly try to override it, too.
+        greeter = new ArcticaGreeter (false);
+        GLib.assert (true == greeter.test_mode);
+    }
+
     public static void simple_navigation ()
     {
         MainWindow mw = setup ();
@@ -486,11 +501,12 @@ public class Test
         GLib.assert (list.selected_entry.id == "*remote_login*http://rdpdefaultusername2.com*lwola");
         wait_for_scrolling_end (list);
 
-        ArcticaGreeter.singleton.session_started = false;
+        var greeter = new ArcticaGreeter ();
+        greeter.session_started = false;
         pwd = remote_login_entry_password_field (list);
         pwd.text = "password";
         list.selected_entry.respond ({});
-        GLib.assert (ArcticaGreeter.singleton.session_started);
+        GLib.assert (greeter.session_started);
 
         mw.hide ();
     }
@@ -516,7 +532,8 @@ public class Test
         GLib.assert (list.selected_entry.id == "*remote_login*http://rdpdefaultusername2.com*lwola");
         wait_for_scrolling_end (list);
 
-        ArcticaGreeter.singleton.session_started = false;
+        var greeter = new ArcticaGreeter ();
+        greeter.session_started = false;
         pwd = remote_login_entry_password_field (list);
         pwd.text = "delay";
         pwd.activate ();
@@ -650,14 +667,15 @@ public class Test
         username.text = "bar";
         pwd.text = "foobar";
 
-        ArcticaGreeter.singleton.show_prompt("remote login:", LightDM.PromptType.QUESTION);
-        GLib.assert (ArcticaGreeter.singleton.last_respond_response == username.text);
-        ArcticaGreeter.singleton.show_prompt("remote host:", LightDM.PromptType.QUESTION);
-        GLib.assert (ArcticaGreeter.singleton.last_respond_response == "http://coolrdpserver.com");
-        ArcticaGreeter.singleton.show_prompt("domain:", LightDM.PromptType.QUESTION);
-        GLib.assert (ArcticaGreeter.singleton.last_respond_response == domain.text);
-        ArcticaGreeter.singleton.show_prompt("password:", LightDM.PromptType.SECRET);
-        GLib.assert (ArcticaGreeter.singleton.last_respond_response == pwd.text);
+        var greeter = new ArcticaGreeter ();
+        greeter.show_prompt("remote login:", LightDM.PromptType.QUESTION);
+        GLib.assert (greeter.last_respond_response == username.text);
+        greeter.show_prompt("remote host:", LightDM.PromptType.QUESTION);
+        GLib.assert (greeter.last_respond_response == "http://coolrdpserver.com");
+        greeter.show_prompt("domain:", LightDM.PromptType.QUESTION);
+        GLib.assert (greeter.last_respond_response == domain.text);
+        greeter.show_prompt("password:", LightDM.PromptType.SECRET);
+        GLib.assert (greeter.last_respond_response == pwd.text);
 
         mw.hide ();
     }
@@ -690,15 +708,16 @@ public class Test
 
     public static void remote_login_only ()
     {
-        ArcticaGreeter.singleton.test_mode = true;
-        ArcticaGreeter.singleton.session_started = false;
+        var greeter = new ArcticaGreeter ();
+        greeter.test_mode = true;
+        greeter.session_started = false;
 
 	/* this configuration should result in the list containing only the remote login entry,
 	   without any fallback manual entry */
-        ArcticaGreeter.singleton._hide_users_hint = true;
-        ArcticaGreeter.singleton._show_remote_login_hint = true;
-        ArcticaGreeter.singleton._has_guest_account_hint = false;
-        ArcticaGreeter.singleton._show_manual_login_hint = false;
+        greeter._hide_users_hint = true;
+        greeter._show_remote_login_hint = true;
+        greeter._has_guest_account_hint = false;
+        greeter._show_manual_login_hint = false;
 
         MainWindow mw = setup ();
         TestList list = mw.stack.top () as TestList;
@@ -725,14 +744,15 @@ public class Test
 
    public static void manual_login_fallback ()
    {
-        ArcticaGreeter.singleton.test_mode = true;
-        ArcticaGreeter.singleton.session_started = false;
+        var greeter = new ArcticaGreeter ();
+        greeter.test_mode = true;
+        greeter.session_started = false;
 
 	/* this configuration should result in the list containing at least a manual entry */
-        ArcticaGreeter.singleton._hide_users_hint = true;
-        ArcticaGreeter.singleton._show_remote_login_hint = false;
-        ArcticaGreeter.singleton._has_guest_account_hint = false;
-        ArcticaGreeter.singleton._show_manual_login_hint = true;
+        greeter._hide_users_hint = true;
+        greeter._show_remote_login_hint = false;
+        greeter._has_guest_account_hint = false;
+        greeter._show_manual_login_hint = true;
 
         MainWindow mw = setup ();
         TestList list = mw.stack.top () as TestList;
@@ -782,9 +802,9 @@ public class Test
 
         setup_gsettings ();
 
-        ArcticaGreeter.singleton = new ArcticaGreeter();
-        ArcticaGreeter.singleton.test_mode = true;
+        var greeter = new ArcticaGreeter (true);
 
+        GLib.Test.add_func ("/Greeter Test Mode", greeter_test_mode);
         GLib.Test.add_func ("/Simple Navigation", simple_navigation);
         GLib.Test.add_func ("/Remote Login", remote_login);
         GLib.Test.add_func ("/Remote Login duplicate entries", remote_login_duplicate_entries);


### PR DESCRIPTION
This PR contains a lot of changes to the High Contrast mode and adds a Big Font mode stub. The latter one doesn't do anything yet.

In High Contrast mode, several widgets now change their looks - for instance, user cards now switch to a white background with black text, the session selection list likewise is drawn with more contrast, the transparency of the menubar is removed (as far as the GTK theme would allow it) and the machine name text on the menubar switched to a pure white color.

This is strictly a WIP. @sunweaver requested other changes, which I am currently working on, but also that I get the code merged in as-is to have a base to work with.