### PR TITLE
Don't truncate PAM messages and misc. fixes.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -37,6 +37,7 @@ AC_DEFINE_UNQUOTED([INDICATOR_FILE_DIR], ["${prefix}/share/ayatana/indicators"],
 
 INDICATORDIR=`$PKG_CONFIG --variable=indicatordir ayatana-indicator3-0.4`
 AC_SUBST(INDICATORDIR)
+AC_DEFINE_UNQUOTED([INDICATORDIR], ["$INDICATORDIR"], [Indicator plugins files are loaded from this directory])
 
 if $PKG_CONFIG --exists mate-settings-daemon; then
     MSD_BINARY=`$PKG_CONFIG --variable=binary mate-settings-daemon`

--- a/src/arctica-greeter.vala
+++ b/src/arctica-greeter.vala
@@ -113,8 +113,8 @@ public class ArcticaGreeter : Object
      *
      * Making the parameter optional is a good compromise.
      *
-     * This this parameter is construct-only, initializing it by passing it to
-     * the GObject constructor is both the correct way to do it, and it will
+     * This parameter is construct-only, initializing it by passing it to the
+     * GObject constructor is both the correct way to do it, and it will
      * additionally avoid changing it in later calls of our constructor.
      */
     public ArcticaGreeter (bool test_mode_ = false,

--- a/src/prompt-box.vala
+++ b/src/prompt-box.vala
@@ -574,7 +574,7 @@ public class PromptBox : FadableBox
 
         Gdk.RGBA color = { 1.0f, 1.0f, 1.0f, 1.0f };
         if (is_error) {
-            color.parse ("#df382c");
+            color.parse ("#820900");
 
             /*
              * Overriding the background color will look ugly, but at least

--- a/src/prompt-box.vala
+++ b/src/prompt-box.vala
@@ -555,6 +555,7 @@ public class PromptBox : FadableBox
     public void add_message (string text, bool is_error)
     {
         var label = new FadingLabel (text);
+        label.set_line_wrap (true);
 
         var style_ctx = label.get_style_context();
 

--- a/src/prompt-box.vala
+++ b/src/prompt-box.vala
@@ -573,9 +573,20 @@ public class PromptBox : FadableBox
         }
 
         Gdk.RGBA color = { 1.0f, 1.0f, 1.0f, 1.0f };
-        if (is_error)
+        if (is_error) {
             color.parse ("#df382c");
+
+            /*
+             * Overriding the background color will look ugly, but at least
+             * always make the text readable, which is probably important for
+             * error messages.
+             * We probably want to find a better way of handling this.
+             */
+            Gdk.RGBA bg_color = { 1.0f, 1.0f, 1.0f, 1.0f };
+            label.override_background_color (Gtk.StateFlags.NORMAL, bg_color);
+        }
         label.override_color (Gtk.StateFlags.NORMAL, color);
+
 
         label.xalign = 0.0f;
         label.set_data<bool> ("prompt-box-is-error", is_error);

--- a/tests/arctica-greeter.vala
+++ b/tests/arctica-greeter.vala
@@ -22,8 +22,6 @@ public const int grid_size = 40;
 [SingleInstance]
 public class ArcticaGreeter : Object
 {
-    public static ArcticaGreeter singleton;
-
     public signal void show_message (string text, LightDM.MessageType type);
     public signal void show_prompt (string text, LightDM.PromptType type);
     public signal void authentication_complete ();


### PR DESCRIPTION
This patch series contains a few miscellaneous fixes (nothing functional, just cleanups and passing one additional variable down the build system chain) and introduces a change that stops the greeter from truncating PAM (error) messages and improves their readability.

Technically, not truncating the PAM messages leads to another problem, which this series does NOT fix yet: each additional line will enlarge the user card box internally, but not externally, so things on the bottom will eventually be cut off (like the password input field).

Fixing that is more complicated, but fortunately, there is a workaround to this bug - clicking on the session selection button in the user card box and then back makes it correctly-sized for the last shown PAM message.