### PR TITLE
Make logo alpha value configurable via dconf

### DIFF
--- a/data/org.ArcticaProject.arctica-greeter.gschema.xml
+++ b/data/org.ArcticaProject.arctica-greeter.gschema.xml
@@ -77,6 +77,10 @@
       <default>'/usr/share/arctica-greeter/logo.png'</default>
       <summary>Logo file to use</summary>
     </key>
+    <key name="logo-alpha" type="d">
+      <default>0.5</default>
+      <summary>Alpha value for blending the logo onto the background</summary>
+    </key>
     <key name="theme-name" type="s">
       <default>'Numix'</default>
       <summary>GTK+ theme to use</summary>

--- a/src/background.vala
+++ b/src/background.vala
@@ -208,7 +208,7 @@ class BackgroundLoader : Object
             var y = (int) (image.height / grid_size - 2) * grid_size + grid_y_offset;
             bc.translate (x, y);
             bc.set_source_surface (logo, 0, 0);
-            bc.paint_with_alpha (0.5);
+            bc.paint_with_alpha (AGSettings.get_double (AGSettings.KEY_LOGO_ALPHA));
             bc.restore ();
         }
 

--- a/src/settings.vala
+++ b/src/settings.vala
@@ -33,6 +33,7 @@ public class AGSettings : Object
     public const string KEY_DRAW_GRID = "draw-grid";
     public const string KEY_SHOW_HOSTNAME = "show-hostname";
     public const string KEY_LOGO = "logo";
+    public const string KEY_LOGO_ALPHA = "logo-alpha";
     public const string KEY_THEME_NAME = "theme-name";
     public const string KEY_HIGH_CONTRAST_THEME_NAME = "high-contrast-theme-name";
     public const string KEY_ICON_THEME_NAME = "icon-theme-name";


### PR DESCRIPTION
As mentioned in #21, the logo alpha value was hardcoded to 0.5.

This makes it configurable via the new dconf key `logo-alpha`.