### PR TITLE
Fix tiny main window on startup.

### DIFF
--- a/src/arctica-greeter.vala
+++ b/src/arctica-greeter.vala
@@ -437,6 +437,8 @@ public class ArcticaGreeter : Object
         debug ("Showing main window");
         if (!test_mode)
             main_window.set_decorated (false);
+        main_window.realize ();
+        main_window.setup_window ();
         main_window.show ();
         main_window.get_window ().focus (Gdk.CURRENT_TIME);
         main_window.set_keyboard_state ();


### PR DESCRIPTION
3a5ca24831d1b4a74af6cfd5c5cc2a42b5787aeb backported a commit calculating the really needed screen size more correctly as a prerequisite for additional multi-display support (span and zoom modes) from Slick Greeter (5d39cade1f70ffe0a9bc38ad0b405bb55d98a505), but unfortunately missed crucial code in `src/arctica-greeter.vala`.

While the `realize` call on `main_window` should be harmless, calling `setup_window` on it actually leads to the main window resizing to the actual size that was queried via GDK.

While `setup_window` is being called as part of the main window creation, the first call just skips resizing it (for some reason). Subsequent calls, which are *mostly* triggered through changes in the actual display configuration (hardware or software), then have main window recalculate its size (and updating the background).

Honestly, we could just rip out the whole `do_resize` logic and always resize, since with these changes, we're forcing a resize on startup anyway. Not doing so leads to the nasty bug this commit fixes.

However, to keep Slick Greeter's and our code more in sync (to make future backporting easier), let's keep it like this for now.

Fixes: https://github.com/ArcticaProject/arctica-greeter/issues/47