### PR TITLE
GTK+ 3/GTK 4 switching support.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -20,8 +20,6 @@ dnl ###########################################################################
 
 dnl #### removed from PKG_CHECK_MODULES: libido3-0.
 PKG_CHECK_MODULES(ARCTICA_GREETER, [
-    gtk+-3.0
-    gdk-x11-3.0
     libayatana-ido3-0.4 >= 0.4.0
     ayatana-indicator3-0.4 >= 0.6.0
     liblightdm-gobject-1 >= 1.12.0
@@ -32,6 +30,47 @@ PKG_CHECK_MODULES(ARCTICA_GREETER, [
     x11
     xext
 ])
+
+dnl GTK version selection.
+AC_MSG_CHECKING([whether to enable GTK 4 support])
+AC_ARG_ENABLE([gtk4],
+              [AS_HELP_STRING([--disable-gtk4],
+                              [disable support for GTK 4])],
+              [enable_gtk4=$enableval],
+              [enable_gtk4=auto])
+AC_MSG_RESULT([$enable_gtk4])
+with_gtk4=$enable_gtk4
+
+AS_IF([test "x$enable_gtk4" != 'xno'],
+      [PKG_CHECK_MODULES([GTK],
+                         [gtk4
+                          gtk4-x11],
+                         [gtk4_modules=yes],
+                         [gtk4_modules=no])
+       AC_MSG_CHECKING([for GTK 4 libraries])
+       AC_MSG_RESULT([$gtk4_modules])
+       AS_IF([test "x$gtk4_modules" = 'xno'],
+             [AS_IF([test "x$enable_gtk4" != 'xauto'],
+                    [AC_MSG_ERROR([requested GTK 4, but not found])],
+                    [with_gtk4=no])],
+             [with_gtk4=yes
+              AM_VALAFLAGS="$AM_VALAFLAGS -D HAVE_GTK_4_0"
+              AC_SUBST([AM_VALAFLAGS])])])
+AS_IF([test "x$with_gtk4" = 'xno'],
+      [PKG_CHECK_MODULES([GTK],
+                         [gtk+-3.0
+                          gdk-x11-3.0],
+                         [gtk3_modules=yes],
+                         [gtk3_modules=no])
+       AC_MSG_CHECKING([for GTK+ 3 libraries])
+       AC_MSG_RESULT([$gtk3_modules])
+       AS_IF([test "x$gtk3_modules" = 'xno'],
+             [AS_IF([test "x$enable_gtk4" = 'xauto'],
+                    [AC_MSG_ERROR([fallback to GTK+ 3, but not found])],
+                    [AC_MSG_ERROR([requested GTK+ 3, but not found])])])])
+AC_SUBST([GTK_CFLAGS])
+AC_SUBST([GTK_LIBS])
+AM_CONDITIONAL([HAVE_GTK4], [test "x$with_gtk4" != 'xno'])
 
 AC_DEFINE_UNQUOTED([INDICATOR_FILE_DIR], ["${prefix}/share/ayatana/indicators"], [Indicator files are searched for in this directory])
 
@@ -86,21 +125,13 @@ dnl ###########################################################################
 dnl Check for GTK version - 3.20
 dnl ###########################################################################
 
-PKG_CHECK_MODULES(GTK_3_20_0, gtk+-3.0 >= 3.20.0 , gtk_check_pass=yes, gtk_check_pass=no)
-if test x$gtk_check_pass = xyes ; then
-  AM_VALAFLAGS="$AM_VALAFLAGS -D HAVE_GTK_3_20_0"
-  AC_SUBST([AM_VALAFLAGS])
-fi
-
-dnl ###########################################################################
-dnl Check for GTK version - 4.0
-dnl ###########################################################################
-
-PKG_CHECK_MODULES(GTK_4_0, gtk4 >= 4.0.0 , gtk4_check_pass=yes, gtk4_check_pass=no)
-if test x$gtk4_check_pass = xyes ; then
-  AM_VALAFLAGS="$AM_VALAFLAGS -D HAVE_GTK_4_0"
-  AC_SUBST([AM_VALAFLAGS])
-fi
+AS_IF([test "x$with_gtk4" != 'xno'],
+      [AM_VALAFLAGS="$AM_VALAFLAGS -D HAVE_GTK_3_20_0"
+       AC_SUBST([AM_VALAFLAGS])],
+      [PKG_CHECK_MODULES([GTK_3_20_0], [gtk+-3.0 >= 3.20.0], [gtk_check_pass=yes], [gtk_check_pass=no])
+       AS_IF([test "x$gtk_check_pass" = 'xyes'],
+             [AM_VALAFLAGS="$AM_VALAFLAGS -D HAVE_GTK_3_20_0"
+              AC_SUBST([AM_VALAFLAGS])])])
 
 dnl ##########################################################################
 dnl Remote Logon Dependencies
@@ -140,6 +171,8 @@ echo "
         compiler:                   ${CC}
         cflags:                     ${CFLAGS}
         cppflags:                   ${CPPFLAGS}
+
+        GTK 4:                      ${with_gtk4}
 
         GETTEXT_PACKAGE:            ${GETTEXT_PACKAGE}
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -44,6 +44,7 @@ logo_generator_SOURCES = logo-generator.vala
 
 arctica_greeter_CFLAGS = \
 	$(ARCTICA_GREETER_CFLAGS) \
+	$(GTK_CFLAGS) \
 	-w \
 	-DGETTEXT_PACKAGE=\"$(GETTEXT_PACKAGE)\" \
 	-DLOCALEDIR=\"$(localedir)\" \
@@ -58,8 +59,21 @@ arctica_greeter_VALAFLAGS = \
 	$(AM_VALAFLAGS) \
 	--debug \
 	--pkg posix \
+	$(NULL)
+
+if HAVE_GTK4
+arctica_greeter_VALAFLAGS += \
+	--pkg gtk4 \
+	--pkg gtk4-x11 \
+	$(NULL)
+else
+arctica_greeter_VALAFLAGS += \
 	--pkg gtk+-3.0 \
 	--pkg gdk-x11-3.0 \
+	$(NULL)
+endif
+
+arctica_greeter_VALAFLAGS += \
 	--pkg gio-unix-2.0 \
 	--pkg x11 \
 	--pkg liblightdm-gobject-1 \
@@ -72,6 +86,7 @@ logo_generator_VALAFLAGS = $(arctica_greeter_VALAFLAGS)
 
 arctica_greeter_LDADD = \
 	$(ARCTICA_GREETER_LIBS) \
+	$(GTK_LIBS) \
 	-lm
 
 logo_generator_LDADD = $(arctica_greeter_LDADD)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -41,6 +41,7 @@ arctica_greeter_test_SOURCES = \
 
 arctica_greeter_test_CFLAGS = \
 	$(ARCTICA_GREETER_CFLAGS) \
+	$(GTK_CFLAGS) \
 	-w \
 	-DGETTEXT_PACKAGE=\"$(GETTEXT_PACKAGE)\" \
 	-DLOCALEDIR=\""$(localedir)"\" \
@@ -52,8 +53,21 @@ arctica_greeter_test_CFLAGS = \
 arctica_greeter_test_VALAFLAGS = \
 	--debug \
 	--pkg posix \
+	$(NULL)
+
+if HAVE_GTK4
+arctica_greeter_test_VALAFLAGS += \
+	--pkg gtk4 \
+	--pkg gtk4-x11 \
+	$(NULL)
+else
+arctica_greeter_test_VALAFLAGS += \
 	--pkg gtk+-3.0 \
 	--pkg gdk-x11-3.0 \
+	$(NULL)
+endif
+
+arctica_greeter_test_VALAFLAGS += \
 	--pkg gio-unix-2.0 \
 	--pkg x11 \
 	--pkg liblightdm-gobject-1 \
@@ -64,6 +78,7 @@ arctica_greeter_test_VALAFLAGS = \
 
 arctica_greeter_test_LDADD = \
 	$(ARCTICA_GREETER_LIBS) \
+	$(GTK_LIBS) \
 	-lm
 
 CLEANFILES = \


### PR DESCRIPTION
This PR adds a `--disable-gtk4` configure flag.

Previously, the `HAVE_GTK_4_0` macro has been enabled whenever GTK 4 development files were found on the system.

We keep that behavior, and actually modify the build system to actually build and link against GTK 4, but also add a new configure flag `--disable-gtk4` that disables GTK 4 usage.
    
The logic goes like that:
  - If `--disable-gtk4` has not been provided, configure will first look for GTK 4 and use that if available, otherwise fall back to GTK+ 3.
  - If `--disable-gtk4` has been provided, GTK 4 detection is skipped and only GTK+ 3 is detected.
  - If `--enable-gtk4` has been provided, configure will check for GTK 4 and not fall back to GTK+ 3, but error out if GTK 4 has not been found.
    
Note that making GTK 4 the default might not be the best option currently, because the greeter does not build against GTK 4, but is paving the way for the future.
    
For now, users will have to use `--disable-gtk4`, up until all code has been fully ported to support GTK 4.
    
Fixes: https://github.com/ArcticaProject/arctica-greeter/issues/56