### PR TITLE
a11y: Disable background image when in high-contrast mode.

### DIFF
--- a/data/org.ArcticaProject.arctica-greeter.gschema.xml
+++ b/data/org.ArcticaProject.arctica-greeter.gschema.xml
@@ -9,6 +9,10 @@
       <default>'#4B1635'</default>
       <summary>Background color (e.g. #772953), set before wallpaper is seen</summary>
     </key>
+    <key name="high-contrast-background-color" type="s">
+      <default>'#000000'</default>
+      <summary>Background color (e.g. #000000 or #FFFFFF) for high contrast mode</summary>
+    </key>
     <key name="togglebox-font-fgcolor" type="s">
       <default>'#808080'</default>
       <summary>Font foreground color (e.g. #A0A0A0) for non-active/-hovered and non-selected session names in the session list</summary>

--- a/src/background.vala
+++ b/src/background.vala
@@ -476,14 +476,19 @@ public class Background : Gtk.Fixed
         }
 
         set {
+            var pretty_value = "";
+
             if (value == null || value == "")
             {
                 _current_background = system_background;
+                pretty_value = "<system default bg image> ";
             } else
             {
                 _current_background = value;
             }
+            pretty_value += _current_background;
 
+            debug ("Background change requested, changing to: %s", pretty_value);
             reload ();
         }
     }

--- a/src/background.vala
+++ b/src/background.vala
@@ -677,7 +677,8 @@ public class Background : Gtk.Fixed
 
         c.restore ();
 
-        if (DrawFlags.GRID in flags)
+        var agsettings = new AGSettings();
+        if ((DrawFlags.GRID in flags) && (!agsettings.high_contrast))
             overlay_grid (c);
     }
 

--- a/src/background.vala
+++ b/src/background.vala
@@ -421,6 +421,25 @@ public class Background : Gtk.Fixed
         }
     }
 
+    private string _highcontrast_bgcolor = null;
+    public string highcontrast_bgcolor {
+        get {
+            if (_highcontrast_bgcolor == null)
+            {
+                var settings_bgcolor = AGSettings.get_string (AGSettings.KEY_HIGH_CONTRAST_BACKGROUND_COLOR);
+                var color = Gdk.RGBA ();
+
+                if (settings_bgcolor == "" || !color.parse (settings_bgcolor))
+                {
+                    settings_bgcolor = "#000000";
+                }
+
+                _highcontrast_bgcolor = settings_bgcolor;
+            }
+            return _highcontrast_bgcolor;
+        }
+    }
+
     private string _system_background;
     public string? system_background {
         get {
@@ -722,7 +741,12 @@ public class Background : Gtk.Fixed
 
     private BackgroundLoader load_background (string? filename)
     {
-        if (filename == null)
+        var agsettings = new AGSettings ();
+        if (agsettings.high_contrast)
+        {
+            filename = highcontrast_bgcolor;
+        }
+        else if (filename == null)
         {
             filename = fallback_bgcolor;
         } else

--- a/src/settings.vala
+++ b/src/settings.vala
@@ -28,6 +28,7 @@ public class AGSettings : Object
 {
     public const string KEY_BACKGROUND = "background";
     public const string KEY_BACKGROUND_COLOR = "background-color";
+    public const string KEY_HIGH_CONTRAST_BACKGROUND_COLOR = "high-contrast-background-color";
     public const string KEY_BACKGROUND_MODE = "background-mode";
     public const string KEY_DRAW_USER_BACKGROUNDS = "draw-user-backgrounds";
     public const string KEY_DRAW_GRID = "draw-grid";

--- a/src/user-list.vala
+++ b/src/user-list.vala
@@ -173,7 +173,10 @@ public class UserList : GreeterList
     construct
     {
         var agsettings = new AGSettings ();
-        agsettings.notify["high-contrast"].connect (() => { change_background (); });
+        agsettings.notify[AGSettings.KEY_HIGH_CONTRAST].connect (() => {
+            change_background ();
+            debug ("High contrast switched toggled, new switch state is %b; adjusting background.", AGSettings.get_boolean(AGSettings.KEY_HIGH_CONTRAST));
+        });
         entry_displayed_start.connect (() => { change_background (); });
         entry_displayed_done.connect (() => { change_background (); });
 


### PR DESCRIPTION
This adds a configurable 'high-contrast-background-color' gsetting parameter (defaulting to #000000), so the high contrast bgcolor becomes customizable.