### PR TITLE
GreeterList: Fix check for LightDM.PromptType.SECRET, let screen read…

### DIFF
--- a/src/greeter-list.vala
+++ b/src/greeter-list.vala
@@ -302,7 +302,7 @@ public abstract class GreeterList : FadableBox
 
         string accessible_text = null;
         if (selected_entry != null && selected_entry.label != null) {
-            if (secret)
+            if (secret == true)
                 accessible_text = _("Enter password for %s").printf (selected_entry.label);
             else
                 accessible_text = _("Enter your username");


### PR DESCRIPTION
…er read "Enter username" instead of "Enter password for &lt;user>".

Fixes: https://github.com/ArcticaProject/arctica-greeter/issues/72