### PR TITLE
settings: Add font scaling via GDK_DPI_SCALE. This is not adjustable at runtime (for now).

### DIFF
--- a/data/org.ArcticaProject.arctica-greeter.gschema.xml
+++ b/data/org.ArcticaProject.arctica-greeter.gschema.xml
@@ -187,6 +187,10 @@
       <default>'auto'</default>
       <summary>Whether to enable HiDPI support</summary>
     </key>
+    <key name="font-scaling" type="d">
+      <default>1.0</default>
+      <summary>Scaling factor for fonts that can be used to adjust the greeter's font sizes.</summary>
+    </key>
     <key name="menubar-alpha" type="d">
       <default>0.5</default>
       <summary>Alpha value for menubar, multiplied with the theme-provided transparency value. Not used in high contrast mode.</summary>

--- a/src/arctica-greeter.vala
+++ b/src/arctica-greeter.vala
@@ -974,6 +974,14 @@ public class ArcticaGreeter : Object
         debug ("Setting GDK_SCALE to: %d (scaling all UI elements by this factor)", scaling_factor_hidpi);
         GLib.Environment.set_variable ("GDK_SCALE", "%d".printf (scaling_factor_hidpi), true);
 
+        /* Font scaling settings */
+        var scaling_factor_fonts = AGSettings.get_double (AGSettings.KEY_FONT_SCALING);
+        debug ("Scaling factor for fonts is: %f", scaling_factor_fonts);
+
+        /* Adjust GDK_SCALE / GDK_DPI_SCALE to our configured scaling factors. */
+        debug ("Setting GDK_DPI_SCALE to: %f (scaling fonts only by this factor)", scaling_factor_fonts);
+        GLib.Environment.set_variable ("GDK_DPI_SCALE", "%f".printf (scaling_factor_fonts), true);
+
         /* Make nm-applet hide items the user does not have permissions to interact with */
         Environment.set_variable ("NM_APPLET_HIDE_POLICY_ITEMS", "1", true);
 

--- a/src/settings.vala
+++ b/src/settings.vala
@@ -73,6 +73,7 @@ public class AGSettings : Object
     public const string KEY_FLATBUTTON_BGCOLOR = "flatbutton-bgcolor";
     public const string KEY_FLATBUTTON_BORDERCOLOR = "flatbutton-bordercolor";
     public const string KEY_ENABLE_HIDPI = "enable-hidpi";
+    public const string KEY_FONT_SCALING = "font-scaling";
     public const string KEY_MENUBAR_ALPHA = "menubar-alpha";
     public const string KEY_HIDE_DEFAULT_XSESSION = "hide-default-xsession";
     public const string KEY_HIDE_X11_SESSIONS = "hide-x11-sessions";


### PR DESCRIPTION
This depends on #84.