### PR TITLE
Add polkit >= 0.106 support

### DIFF
--- a/data/50-org.Arctica-Project.arctica-greeter.rules
+++ b/data/50-org.Arctica-Project.arctica-greeter.rules
@@ -1,0 +1,33 @@
+polkit.addRule (function (action, subject) {
+  if (subject.user == "lightdm") {
+    switch (action.id) {
+      // Disable Controlling of Network Devices
+      case 'org.freedesktop.NetworkManager.enable-disable-network':
+      case 'org.freedesktop.NetworkManager.enable-disable-wifi':
+      case 'org.freedesktop.NetworkManager.enable-disable-wwan':
+      case 'org.freedesktop.NetworkManager.enable-disable-wimax':
+      // Disable Sleep and Wake
+      case 'org.freedesktop.NetworkManager.sleep-wake':
+      // Disable WiFi Sharing
+      case 'org.freedesktop.NetworkManager.wifi.share.protected':
+      case 'org.freedesktop.NetworkManager.wifi.share.open':
+      // Disable Settings Modifications
+      case 'org.freedesktop.NetworkManager.settings.modify.own':
+      case 'org.freedesktop.NetworkManager.settings.modify.system':
+      case 'org.freedesktop.NetworkManager.settings.modify.hostname':
+      // Disable User Connections
+      case 'org.freedesktop.NetworkManager.use-user-connections':
+      // Enable Controlling of Network Connections
+      case 'org.freedesktop.NetworkManager.network-control':
+        return polkit.Result.NO;
+        break;
+      default:
+        /*
+         * Do nothing... for now.
+         *
+         * This means that polkit will continue scanning for other rules.
+         */
+        break;
+    }
+  }
+});

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -26,6 +26,11 @@ pkla_policy_DATA = \
 	arctica-greeter.pkla \
 	$(NULL)
 
+rules_policydir = $(datadir)/polkit-1/rules.d/
+rules_policy_DATA = \
+	50-org.Arctica-Project.arctica-greeter.rules \
+	$(NULL)
+
 arctica-greeter-guest-session-startup.desktop: arctica-greeter-guest-session-startup.desktop.in
 	$(AM_V_GEN) sed -e "s|\@pkglibexecdir\@|$(pkglibexecdir)|" $< > $@
 

--- a/data/arctica-greeter.pkla
+++ b/data/arctica-greeter.pkla
@@ -6,39 +6,39 @@ Identity=unix-user:lightdm
 Action=org.freedesktop.NetworkManager.enable-disable-network;org.freedesktop.NetworkManager.enable-disable-wifi;org.freedesktop.NetworkManager.enable-disable-wwan;org.freedesktop.NetworkManager.enable-disable-wimax;
 ResultActive=no
 ResultInactive=no
-ResultsAny=no
+ResultAny=no
 
 [Disable Sleep and Wake]
 Identity=unix-user:lightdm
 Action=org.freedesktop.NetworkManager.sleep-wake
 ResultActive=no
 ResultInactive=no
-ResultsAny=no
+ResultAny=no
 
 [Disable WiFi Sharing]
 Identity=unix-user:lightdm
 Action=org.freedesktop.NetworkManager.wifi.share.protected;org.freedesktop.NetworkManager.wifi.share.open
 ResultActive=no
 ResultInactive=no
-ResultsAny=no
+ResultAny=no
 
 [Disable Settings Modifications]
 Identity=unix-user:lightdm
 Action=org.freedesktop.NetworkManager.settings.modify.own;org.freedesktop.NetworkManager.settings.modify.system;org.freedesktop.NetworkManager.settings.modify.hostname
 ResultActive=no
 ResultInactive=no
-ResultsAny=no
+ResultAny=no
 
 [Disable User Connections]
 Identity=unix-user:lightdm
 Action=org.freedesktop.NetworkManager.use-user-connections
 ResultActive=no
 ResultInactive=no
-ResultsAny=no
+ResultAny=no
 
 [Enable Controlling of Network Connections]
 Identity=unix-user:lightdm
 Action=org.freedesktop.NetworkManager.network-control
 ResultActive=yes
 ResultInactive=no
-ResultsAny=no
+ResultAny=no

--- a/debian/arctica-greeter.install
+++ b/debian/arctica-greeter.install
@@ -7,6 +7,7 @@ usr/share/glib-2.0/
 usr/share/lightdm/lightdm.conf.d/50-arctica-greeter.conf
 usr/share/locale/
 usr/share/man/man1/
+usr/share/polkit-1/rules.d/50-org.Arctica-Project.arctica-greeter.rules
 usr/share/sounds/
 usr/share/xgreeters/
 usr/libexec/arctica-greeter/lightdm-arctica-greeter-session


### PR DESCRIPTION
This PR adds polkit >= 0.106 support via a JS rules file.

It also fixes the old pkla file: `ResultsAny` was never a valid key and thus did never work. `ResultAny` is the correct key.

For more information, refer to the individual commit messages.